### PR TITLE
small refactor to move to pure functions in visitors/linker

### DIFF
--- a/src/linker/steps/link.js
+++ b/src/linker/steps/link.js
@@ -1,5 +1,5 @@
 import { visit } from '../../visitors/visiting'
-import { filtering, onExit } from '../../visitors/commons'
+import { filtering } from '../../visitors/commons'
 import { linkeables } from '../definitions'
 import { findInScope } from '../scoping'
 import { appendError, createUnresolvedLinkageError, createWrongTypeLinkageError } from '../errors'
@@ -12,10 +12,10 @@ export const Ref = (token, node) => Node(Ref)({ token, node })
 
 const isLinkeable = ({ type }) => linkeables[type]
 
-export const linkStep = visit(filtering(isLinkeable, onExit(n => {
+export const linkStep = visit(filtering(isLinkeable, n => {
   const { type } = n
   doLink(n, linkeables[type])
-})))
+}))
 
 const doLink = (node, linkDef) => Object.keys(linkDef).forEach(feature => {
   link(node, feature, linkDef[feature])

--- a/src/transformations.js
+++ b/src/transformations.js
@@ -1,4 +1,4 @@
-import { Assignment, Block, Catch, Class, Closure, Constructor, Field, File, If, List, Method, Module, New, Node, Package, Return, Runnable, Send, Super, Try, Variable, VariableDeclaration, traverse } from './model'
+import { Assignment, Block, Catch, Class, Closure, Constructor, Field, File, If, List, Method, Module, New, Node, Package, Return, Runnable, Send, Super, Try, VariableDeclaration, traverse } from './model'
 
 export const addDefaultConstructor = traverse({
   [File]: ({ content }) => File(...content.map(addDefaultConstructor)),

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,4 +1,5 @@
 export const noop = () => {}
+export const isFunction = o => typeof o === 'function'
 
 // not sure how to support varargs, but I don't need them right now :P
 export const pipe = (fns) => (arg) => fns.reduce((n, fn) => fn(n), arg)

--- a/src/visitors/commons.js
+++ b/src/visitors/commons.js
@@ -1,12 +1,15 @@
 import { visit } from './visiting'
-import { filter } from '../utils/functions'
+import { filter, isFunction } from '../utils/functions'
 
 // common high-level visitors
 
 export const onEnter = enter => ({ enter })
 export const onExit = exit => ({ exit })
 
-export const filtering = (condition, { enter, exit }) => ({
+export const filtering = (condition, fnOrVisitor) =>
+  filteringVisitor(condition, isFunction(fnOrVisitor) ? { enter: fnOrVisitor } : fnOrVisitor)
+
+const filteringVisitor = (condition, { enter, exit }) => ({
   ...(enter && { enter: filter(condition, enter) }),
   ...(exit && { exit: filter(condition, exit) })
 })


### PR DESCRIPTION
making filtering() support both a visitor (object) or a function. Allows client code to work with simple functions